### PR TITLE
fix errors caught by linter.

### DIFF
--- a/recipes/openvdb/meta.yaml
+++ b/recipes/openvdb/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "openvdb" %}
 {% set version = "10.0.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: openvdb
   version: {{ version }}
 
 source:
-  url: https://github.com/AcademySoftwareFoundation/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 887a3391fbd96b20c77914f4fb3ab4b33d26e5fc479aa036d395def5523c622f
 
 build:
@@ -31,16 +30,16 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libopenvdb.so.{{ version }} # [unix]
-    - test -f ${PREFIX}/lib/libopenvdb.so # [unix]
-    - test -f ${PREFIX}/bin/vdb_print # [unix]
-    - test -f ${PREFIX}/include/openvdb/openvdb.h # [unix]
-    - test -f ${PREFIX}/lib/cmake/OpenVDB/FindOpenVDB.cmake # [unix]
-    - if not exist %PREFIX%\lib\libopenvdb.dll.{{ version }} exit 1 # [win]
-    - if not exist %PREFIX%\lib\libopenvdb.dll exit 1 # [win]
-    - if not exist %PREFIX%\bin\vdb_print exit 1 # [win]
-    - if not exist %PREFIX%\include\opendb\opendvdb.h exit 1 # [win]
-    - if not exist %PREFIX%\lib\cmake\FindOpenVDB.cmake exit 1 # [win]
+    - test -f ${PREFIX}/lib/libopenvdb.so.{{ version }}  # [unix]
+    - test -f ${PREFIX}/lib/libopenvdb.so  # [unix]
+    - test -f ${PREFIX}/bin/vdb_print  # [unix]
+    - test -f ${PREFIX}/include/openvdb/openvdb.h  # [unix]
+    - test -f ${PREFIX}/lib/cmake/OpenVDB/FindOpenVDB.cmake  # [unix]
+    - if not exist %PREFIX%\lib\libopenvdb.dll.{{ version }} exit 1  # [win]
+    - if not exist %PREFIX%\lib\libopenvdb.dll exit 1  # [win]
+    - if not exist %PREFIX%\bin\vdb_print exit 1  # [win]
+    - if not exist %PREFIX%\include\opendb\opendvdb.h exit 1  # [win]
+    - if not exist %PREFIX%\lib\cmake\FindOpenVDB.cmake exit 1  # [win]
     - vdb_print --help
 
 about:
@@ -48,8 +47,7 @@ about:
   summary: 'OpenVDB - Sparse volume data structure and tools'
   description: |
     OpenVDB is an open source C++ library comprising a novel hierarchical data structure and a large suite of tools for the efficient storage and manipulation of sparse volumetric data discretized on three-dimensional grids. It was developed by DreamWorks Animation for use in volumetric applications typically encountered in feature film production.
-  license: Mozilla-2.0
-  license_family: Mozilla
+  license: MPL-2.0
   license_file: LICENSE
   dev_url: https://github.com/AcademySoftwareFoundation/openvdb
 


### PR DESCRIPTION
- License: SPDX identifier
- license_family deprecated (https://github.com/conda/conda-build/issues/1780)
- spaces before comment throughout
- removed jinja name variable only used twice